### PR TITLE
Change date-time format in channel name

### DIFF
--- a/response/slack/models/comms_channel.py
+++ b/response/slack/models/comms_channel.py
@@ -17,7 +17,7 @@ class CommsChannelManager(models.Manager):
         """
         Creates a comms channel in slack, and saves a reference to it in the DB
         """
-        time_string = datetime.now().strftime("%b-%-e-%H-%M-%S")
+        time_string = datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
         name = f"inc-{time_string}".lower()
 
         try:


### PR DESCRIPTION
The `time_string` generated for the incident channel name is now `YYYY-mm-dd-HH-MM-SS`.

Channel names now include the year and are easier to sort by name/date since it now uses numeric representation instead of short name for the month.

For example, whereas the channel before was `#inc-may-09-12-09-04` it will now be `#inc-2025-05-09-12-09-04` for an incident reported around 12:09pm on May 9th, 2025.